### PR TITLE
change table name to "spans" instead of "services" and optimise query by …

### DIFF
--- a/s3store/writer.go
+++ b/s3store/writer.go
@@ -118,7 +118,7 @@ func (w *Writer) Close() error {
 func (w *Writer) WriteSpan(span *model.Span) error {
         startTime := span.StartTime.Format(time.RFC3339)
 
-        var labelsWithName = fmt.Sprintf("{__name__=\"services\", env=\"prod\", id=\"%d\", trace_id_low=\"%d\", trace_id_high=\"%d\", flags=\"%d\", duration=\"%d\", tags=\"%s\", process_id=\"%s\", process_tags=\"%s\", warnings=\"%s\", service_name=\"%s\", operation_name=\"%s\", start_time=\"%s\"}",
+        var labelsWithName = fmt.Sprintf("{__name__=\"spans\", env=\"prod\", id=\"%d\", trace_id_low=\"%d\", trace_id_high=\"%d\", flags=\"%d\", duration=\"%d\", tags=\"%s\", process_id=\"%s\", process_tags=\"%s\", warnings=\"%s\", service_name=\"%s\", operation_name=\"%s\", start_time=\"%s\"}",
         span.SpanID,
         span.TraceID.Low,
         span.TraceID.High,


### PR DESCRIPTION
This PR includes two changes, one is a breaking change and another is an optimization.

1. Breaking change that we renamed the table name from "services" to "spans" to better reflect that the data are all the "spans" data and we will need to exclusively use "services" table to get all the services.
2. Time query now is a lot faster with some optimizations to use the indexed timestamp.