### PR TITLE
Use multistage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.gitignore
+Dockerfile
+LICENSE
+README.md
+jaeger-s3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM alpine:3.14.2
+FROM golang:1.17.3-alpine3.14 as BUILD
+WORKDIR /build
+COPY . .
+RUN go build ./cmd/jaeger-s3/
 
-ADD jaeger-s3 /go/bin/jaeger-s3
-
+FROM alpine:3.14.2 as FINAL
+COPY --from=BUILD /build/jaeger-s3 /go/bin/jaeger-s3
 RUN mkdir /plugin
-
 # /plugin/ location is defined in jaeger-operator
-CMD ["cp", "/go/bin/jaeger-s3", "/plugin/jaeger-s3"]
+CMD ["cp", "-r", "/go/bin/jaeger-s3", "/plugin/jaeger-s3"]


### PR DESCRIPTION
This way the build can also be done inside Docker and spare you the necessity to have Go installed on your machine.
Further this can be used to build the binary for Linux on Mac or Windows, or to setup a CI pipeline to publish the latest release to Dockerhub or some other container registry.