### PR TITLE
Major changes to LogQL data structure and refactoring

### DIFF
--- a/s3store/writer.go
+++ b/s3store/writer.go
@@ -34,7 +34,7 @@ var _ io.Closer = (*Writer)(nil)
 //var fooLabelsWithName = "{foo=\"bar\", __name__=\"logs\"}"
 
 var (
-	ctx        = user.InjectOrgID(context.Background(), "data")
+	ctx        = user.InjectOrgID(context.Background(), "fake")
 )
 
 // Writer handles all writes to object store for the Jaeger data model
@@ -52,7 +52,7 @@ type timeRange struct {
 	from, to time.Time
 }
 
-func buildTestStreams(labels string, tr timeRange) logproto.Stream {
+func buildTestStreams(labels string, tr timeRange, line string) logproto.Stream {
         stream := logproto.Stream{
                 Labels:  labels,
                 Entries: []logproto.Entry{},
@@ -61,7 +61,7 @@ func buildTestStreams(labels string, tr timeRange) logproto.Stream {
         for from := tr.from; from.Before(tr.to); from = from.Add(time.Second) {
                 stream.Entries = append(stream.Entries, logproto.Entry{
                         Timestamp: from,
-                        Line:      "Hello there! I'm Jack Sparrow",
+                        Line:      line,
                 })
         }
 
@@ -75,7 +75,8 @@ func newChunk(stream logproto.Stream) chunk.Chunk {
         }
         if !lbs.Has(labels.MetricName) {
                 builder := labels.NewBuilder(lbs)
-                builder.Set(labels.MetricName, "logs")
+                //builder.Set(labels.MetricName, "logs")
+                builder.Set(labels.MetricName, "spans")
                 lbs = builder.Labels()
         }
         from, through := pmodel.TimeFromUnixNano(stream.Entries[0].Timestamp.UnixNano()), pmodel.TimeFromUnixNano(stream.Entries[0].Timestamp.UnixNano())
@@ -90,7 +91,7 @@ func newChunk(stream logproto.Stream) chunk.Chunk {
                 _ = chk.Append(&e)
         }
         chk.Close()
-        c := chunk.NewChunk("data", client.Fingerprint(lbs), lbs, chunkenc.NewFacade(chk, 0, 0), from, through)
+        c := chunk.NewChunk("fake", client.Fingerprint(lbs), lbs, chunkenc.NewFacade(chk, 0, 0), from, through)
         // force the checksum creation
         if err := c.Encode(); err != nil {
                 panic(err)
@@ -143,61 +144,21 @@ func (w *Writer) WriteSpan(span *model.Span) error {
 	        },
         }
 
-        pchk := []chunk.Chunk{}
-        addedSpansChunkIDs := map[string]struct{}{}
+	addedChunkIDs := map[string]struct{}{}
+        plogline := fmt.Sprintf("level=info caller=jaeger component=chunks latency=\"%s\"", span.Duration)
 	for _, tr := range chunksToBuildForTimeRanges {
 
                 // span chunk
-                spanChk := newChunk(buildTestStreams(spanLabelsWithName, tr))
-                addedSpansChunkIDs[spanChk.ExternalKey()] = struct{}{}
-                pchk = append(pchk, spanChk)
+                chk := newChunk(buildTestStreams(spanLabelsWithName, tr, plogline))
+
+                // upload the span chunks
+                err := w.store.PutOne(ctx, chk.From, chk.Through, chk)
+                if err != nil {
+                        log.Println("store spans Put error: %s", err)
+                }
+
+                addedChunkIDs[chk.ExternalKey()] = struct{}{}
 	}
-
-        // upload the span chunks 
-        err := w.store.Put(ctx, pchk)
-        if err != nil {
-                log.Println("store spans Put error: %s", err)
-        }
-
-        // services label
-        var serviceLabelsWithName = fmt.Sprintf("{__name__=\"services\", env=\"prod\", service_name=\"%s\"}", span.Process.ServiceName)
-
-        // services chunk
-        schk := []chunk.Chunk{}
-        addedServicesChunkIDs := map[string]struct{}{}
-        for _, tr := range chunksToBuildForTimeRanges {
-
-                // add slice to services chunk
-                serviceChk := newChunk(buildTestStreams(serviceLabelsWithName, tr))
-                addedServicesChunkIDs[serviceChk.ExternalKey()] = struct{}{}
-                schk = append(schk, serviceChk)
-        }
-
-        // upload the service chunks
-        err = w.store.Put(ctx, schk)
-        if err != nil {
-                log.Println("store services Put error: %s", err)
-        }
-
-        // operations label
-        var operationLabelsWithName = fmt.Sprintf("{__name__=\"operations\", env=\"prod\", operation_name=\"%s\"}", span.OperationName)
-
-        // services chunk
-        ochk := []chunk.Chunk{}
-        addedOperationsChunkIDs := map[string]struct{}{}
-        for _, tr := range chunksToBuildForTimeRanges {
-
-                // add slice to services chunk
-                operationChk := newChunk(buildTestStreams(operationLabelsWithName, tr))
-                addedOperationsChunkIDs[operationChk.ExternalKey()] = struct{}{}
-                ochk = append(ochk, operationChk)
-        }
-
-        // upload the operation chunks
-        err = w.store.Put(ctx, ochk)
-        if err != nil {
-                log.Println("store operations Put error: %s", err)
-        }
 
 	return nil
 }


### PR DESCRIPTION
* Follow LogQL data structure so when we write span data, loki will be able to read and
  do complex queries
* refactor writer to use only one type of data instead
  of separating between operations, services and spans